### PR TITLE
chore : fix installation issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pydantic
 wandb
 python-dotenv
 joblib==1.2.0
-scikit-learn==1.5.1 --only-binary=scikit-learn
+scikit-learn==1.5.1
 pytz

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 # loading version from setup.py
 with codecs.open(
-    os.path.join(here, "template/__init__.py"), encoding="utf-8"
+    os.path.join(here, "scorepredict/__init__.py"), encoding="utf-8"
 ) as init_file:
     version_match = re.search(
         r"^__version__ = ['\"]([^'\"]*)['\"]", init_file.read(), re.M


### PR DESCRIPTION
1. Renamed template/__init__.py to scorepredict/__init__.py to align with the project's structure and ensure proper initialization.
2. Updated requirements.txt by removing the --only-binary flag from scikit-learn to resolve installation errors during pip install.